### PR TITLE
Extract tests from modules in the rebar3 plugin

### DIFF
--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -39,18 +39,15 @@ format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
 extract_tests(Module) ->
-  Exports = Module:module_info(exports),
-  TestNames = lists:filter(fun is_test/1, Exports),
+    Exports = Module:module_info(exports),
+    TestNames = lists:filter(fun is_test/1, Exports),
 
-  lists:map(fun ({Function, Arity}) ->
-    to_fun(Module, Function, Arity)
-  end, TestNames).
+    lists:map(fun({Function, Arity}) -> to_fun(Module, Function, Arity) end, TestNames).
 
 is_test({Name, 0}) ->
-  string:find(atom_to_list(Name), "_", trailing) =:= "_test";
-is_test({_Name, _Arity}) -> false.
+    string:find(atom_to_list(Name), "_", trailing) =:= "_test";
+is_test({_Name, _Arity}) ->
+    false.
 
 to_fun(Module, Function, 0) ->
-  fun() ->
-      erlang:apply(Module, Function, [])
-  end.
+    fun() -> erlang:apply(Module, Function, []) end.

--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -48,7 +48,7 @@ extract_tests(Module) ->
 
 is_test({Name, 0}) ->
   string:find(atom_to_list(Name), "_", trailing) =:= "_test";
-is_test({Name, Arity}) -> false.
+is_test({_Name, _Arity}) -> false.
 
 to_fun(Module, Function, 0) ->
   fun() ->

--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -26,11 +26,9 @@ init(State) ->
 do(State) ->
     rebar_gleam:provider_do(State,
                             fun(State1) ->
-                               compile:file("gen/test/shine_test"),
-                               Pass = fun shine_test:passing/0,
-                               Fail = fun shine_test:failing/0,
+                               {ok, Module} = compile:file("gen/test/test_project_test"),
 
-                               shine:run_suite([{"shine_test", [Pass, Fail]}]),
+                               shine:run_suite([{"test_project_test", extract_tests(Module)}]),
                                {ok, State1}
                             end).
 

--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -39,14 +39,17 @@ format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
 extract_tests(Module) ->
-    Exports = Module:module_info(exports),
-    TestNames = lists:filter(fun is_test/1, Exports),
+    lists:filtermap(fun({Function, Arity}) ->
+                       case is_test(Function, Arity) of
+                           true -> {true, to_fun(Module, Function, Arity)};
+                           false -> false
+                       end
+                    end,
+                    Module:module_info(exports)).
 
-    lists:map(fun({Function, Arity}) -> to_fun(Module, Function, Arity) end, TestNames).
-
-is_test({Name, 0}) ->
+is_test(Name, 0) ->
     string:find(atom_to_list(Name), "_", trailing) =:= "_test";
-is_test({_Name, _Arity}) ->
+is_test(_Name, _Arity) ->
     false.
 
 to_fun(Module, Function, 0) ->

--- a/test/fixtures/test_module.gleam
+++ b/test/fixtures/test_module.gleam
@@ -1,0 +1,3 @@
+pub fn ok_test() {
+  Ok(1)
+}

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -1,0 +1,7 @@
+-module(rebar3_shine_test).
+-include_lib("eunit/include/eunit.hrl").
+ 
+extract_tests_test() ->
+    Module = fixtures@test_module,
+    [Test] = rebar3_shine:extract_tests(Module),
+    ?assertEqual({ok, 1}, Test()).


### PR DESCRIPTION
Instead of using a hardcoded list of functions, as added in
052ebb5ef3ad0236dfa947733fc1e8319b1ef91c, this patch still takes a
hardcoded test module, but automatically extracts the module’s test
functions through `rebar3_shine:extract_tests/1`

Closes #2.