### PR TITLE
Wrap functions in `rescue` blocks in rebar plugin

### DIFF
--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -51,4 +51,4 @@ is_test(_Name, _Arity) ->
     false.
 
 to_fun(Module, Function, 0) ->
-    fun() -> erlang:apply(Module, Function, []) end.
+    fun() -> gleam_stdlib:rescue(fun() -> erlang:apply(Module, Function, []) end) end.

--- a/src/shine.gleam
+++ b/src/shine.gleam
@@ -19,7 +19,9 @@ pub fn run_suite(
   )
 }
 
-pub fn run_case(tests: List(fn() -> Result(a, Exception))) -> List(Result(a, Exception)) {
+pub fn run_case(
+  tests: List(fn() -> Result(a, Exception)),
+) -> List(Result(a, Exception)) {
   list.map(tests, run_test)
 }
 

--- a/src/shine.gleam
+++ b/src/shine.gleam
@@ -8,7 +8,7 @@ pub fn init(state) {
 }
 
 pub fn run_suite(
-  suite: List(tuple(String, List(fn() -> a))),
+  suite: List(tuple(String, List(fn() -> Result(a, Exception)))),
 ) -> List(tuple(String, List(Result(a, Exception)))) {
   list.map(
     suite,
@@ -19,20 +19,20 @@ pub fn run_suite(
   )
 }
 
-pub fn run_case(tests: List(fn() -> a)) -> List(Result(a, Exception)) {
+pub fn run_case(tests: List(fn() -> Result(a, Exception))) -> List(Result(a, Exception)) {
   list.map(tests, run_test)
 }
 
-pub fn run_test(test: fn() -> a) -> Result(a, Exception) {
-  case function.rescue(test) {
+pub fn run_test(test: fn() -> Result(a, Exception)) -> Result(a, Exception) {
+  case test() {
     Error(e) -> {
       io.println("F")
       io.debug(e)
       Error(e)
     }
-    Ok(i) -> {
+    Ok(a) -> {
       io.print(".")
-      Ok(i)
+      Ok(a)
     }
   }
 }

--- a/test/fixtures/passing_test_module.gleam
+++ b/test/fixtures/passing_test_module.gleam
@@ -1,0 +1,3 @@
+pub fn passing_test() {
+  Ok(Nil)
+}

--- a/test/fixtures/passing_test_module.gleam
+++ b/test/fixtures/passing_test_module.gleam
@@ -1,3 +1,3 @@
 pub fn passing_test() {
-  Ok(Nil)
+  Nil
 }

--- a/test/fixtures/test_module.gleam
+++ b/test/fixtures/test_module.gleam
@@ -1,3 +1,0 @@
-pub fn ok_test() {
-  Ok(1)
-}

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -2,6 +2,6 @@
 -include_lib("eunit/include/eunit.hrl").
  
 extract_tests_test() ->
-    Module = fixtures@test_module,
+    Module = fixtures@passing_test_module,
     [Test] = rebar3_shine:extract_tests(Module),
-    ?assertEqual({ok, 1}, Test()).
+    ?assertEqual({ok, nil}, Test()).

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -4,4 +4,4 @@
 extract_tests_test() ->
     Module = fixtures@passing_test_module,
     [Test] = rebar3_shine:extract_tests(Module),
-    ?assertEqual({ok, nil}, Test()).
+    ?assertEqual(nil, Test()).

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -1,7 +1,7 @@
 -module(rebar3_shine_test).
 -include_lib("eunit/include/eunit.hrl").
  
-extract_tests_test() ->
+extract_tests_passing_test() ->
     Module = fixtures@passing_test_module,
     [Test] = rebar3_shine:extract_tests(Module),
-    ?assertEqual(nil, Test()).
+    ?assertEqual({ok, nil}, Test()).

--- a/test/shine_test.gleam
+++ b/test/shine_test.gleam
@@ -1,5 +1,7 @@
 import shine
 import gleam/should
+import gleam/dynamic
+import gleam/function
 
 pub fn run_passing_test() {
   passing
@@ -30,11 +32,9 @@ pub fn run_suite_test() {
 }
 
 pub fn passing() {
-  1
-  |> should.equal(1)
+  Ok(Nil)
 }
 
 pub fn failing() {
-  1
-  |> should.equal(2)
+  Error(function.Errored(dynamic.from("")))
 }


### PR DESCRIPTION
Instead of [wrapping test functions in a rescue block when running
them](https://github.com/jeffkreeftmeijer/shine/blob/d1cf1b1409544ad6087b7df676a407cc6d9b4ee3/src/shine.gleam#L26-L38),
this patch moves the rescuing to the rebar plugin. This makes tests
within the Gleam code a step closer to type safety (as all test
functions are expected to return a `Result`), while still allowing tests
that raise exceptions (as long as they’re loaded through rebar).