### PR TITLE
Implement and use `Test` and `TestModule` types

### DIFF
--- a/test/shine_test.gleam
+++ b/test/shine_test.gleam
@@ -1,30 +1,30 @@
-import shine
+import shine.{Test, TestModule}
 import gleam/should
 import gleam/dynamic
 import gleam/function
 
 pub fn run_passing_test() {
-  passing
+  Test(run: passing)
   |> shine.run_test()
   |> should.be_ok()
 }
 
 pub fn run_failing_test() {
-  failing
+  Test(run: failing)
   |> shine.run_test()
   |> should.be_error()
 }
 
-pub fn run_case_test() {
-  let test_case = [passing]
-  assert [result] = shine.run_case(test_case)
+pub fn run_test_module_test() {
+  let test_module = TestModule(name: "test", tests: [Test(run: passing)])
+  assert tuple("test", [result]) = shine.run_test_module(test_module)
 
   result
   |> should.be_ok()
 }
 
 pub fn run_suite_test() {
-  let suite = [tuple("test", [passing])]
+  let suite = [TestModule(name: "test", tests: [Test(run: passing)])]
   assert [tuple("test", [result])] = shine.run_suite(suite)
 
   result
@@ -32,7 +32,7 @@ pub fn run_suite_test() {
 }
 
 pub fn passing() {
-  Ok(Nil)
+  Ok(dynamic.from(""))
 }
 
 pub fn failing() {


### PR DESCRIPTION
`shine.run_suite/1` doesn't adhere to the proposed `TestFramework` type,
as it returns a list of test results instead of `Nil`. This wasn't
changed because it would hurt testability. A wrapper function that does
not return the test results will be implemented when required.

Also, the `Test` type doesn't include `name` or `sync` fields, as
they're not required by Shine yet. The former will be implemented when
it gains more elaborate output, and the latter when it gains the ability
to run tests asynchronously.

Closes #6.
