### PR TITLE
Use record representation of tests and test_modules in rebar3_shine

### DIFF
--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -28,7 +28,9 @@ do(State) ->
                             fun(State1) ->
                                {ok, Module} = compile:file("gen/test/test_project_test"),
 
-                               shine:run_suite([{"test_project_test", extract_tests(Module)}]),
+                               shine:run_suite([{test_module,
+                                                 "test_project_test",
+                                                 extract_tests(Module)}]),
                                {ok, State1}
                             end).
 
@@ -39,7 +41,7 @@ format_error(Reason) ->
 extract_tests(Module) ->
     lists:filtermap(fun({Function, Arity}) ->
                        case is_test(Function, Arity) of
-                           true -> {true, to_fun(Module, Function, Arity)};
+                           true -> {true, to_test(Module, Function, Arity)};
                            false -> false
                        end
                     end,
@@ -50,5 +52,6 @@ is_test(Name, 0) ->
 is_test(_Name, _Arity) ->
     false.
 
-to_fun(Module, Function, 0) ->
-    fun() -> gleam_stdlib:rescue(fun() -> erlang:apply(Module, Function, []) end) end.
+to_test(Module, Function, 0) ->
+    Fun = fun() -> gleam_stdlib:rescue(fun() -> erlang:apply(Module, Function, []) end) end,
+    {test, Fun}.

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -3,5 +3,5 @@
  
 extract_tests_passing_test() ->
     Module = fixtures@passing_test_module,
-    [Test] = rebar3_shine:extract_tests(Module),
+    [{test, Test}] = rebar3_shine:extract_tests(Module),
     ?assertEqual({ok, nil}, Test()).


### PR DESCRIPTION
A regression caused by #6 broke `rebar3_shine`, because tests are now represented as records:

    ===> Uncaught error: badarg
    ===> Stack trace to the error location:
    [{erlang,element,
             [3,{"test_project_test",[#Fun<rebar3_shine.2.108041178>]}],
             []},
     {shine,run_test_module,1,
            [{file,"/Users/jeff/gleam/test_shine/shine/test_project/_checkouts/shine/gen/src/shine.erl"},
             {line,15}]},
     {gleam@list,do_map,3,
                 [{file,"/Users/jeff/gleam/test_shine/shine/test_project/_build/default/plugins/gleam_stdlib/gen/src/gleam@list.erl"},
                  {line,86}]},
     {rebar3_shine,'-do/1-fun-0-',1,
                   [{file,"/Users/jeff/gleam/test_shine/shine/test_project/_checkouts/shine/src/rebar3_shine.erl"},
                    {line,31}]},
     {rebar_core,do,2,
                 [{file,"/private/var/folders/gf/30sxxc2x18j87dnw9x3ndxd00000gn/T/rebar3-3.14.2/src/rebar_core.erl"},
                  {line,155}]},
     {rebar3,run_aux,2,
             [{file,"/private/var/folders/gf/30sxxc2x18j87dnw9x3ndxd00000gn/T/rebar3-3.14.2/src/rebar3.erl"},
              {line,181}]},
     {rebar3,main,1,
             [{file,"/private/var/folders/gf/30sxxc2x18j87dnw9x3ndxd00000gn/T/rebar3-3.14.2/src/rebar3.erl"},
              {line,66}]},
     {escript,run,2,[{file,"escript.erl"},{line,758}]}]
