### PR TITLE
Use `rebar_prv_compile:do/1` to compile app modules

### DIFF
--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -26,11 +26,12 @@ init(State) ->
 do(State) ->
     rebar_gleam:provider_do(State,
                             fun(State1) ->
-                               Module = test_project_test,
+                               {ok, State2} = rebar_prv_compile:do(State1),
+
                                shine:run_suite([{test_module,
                                                  "test_project_test",
-                                                 extract_tests(Module)}]),
-                               {ok, State1}
+                                                 extract_tests(test_project_test)}]),
+                               {ok, State2}
                             end).
 
 -spec format_error(any()) -> iolist().

--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -26,8 +26,7 @@ init(State) ->
 do(State) ->
     rebar_gleam:provider_do(State,
                             fun(State1) ->
-                               {ok, Module} = compile:file("gen/test/test_project_test"),
-
+                               Module = test_project_test,
                                shine:run_suite([{test_module,
                                                  "test_project_test",
                                                  extract_tests(Module)}]),


### PR DESCRIPTION
Closes #11.