### PR TITLE
Find test modules in gen directory automatically

### DIFF
--- a/src/rebar3_shine.erl
+++ b/src/rebar3_shine.erl
@@ -1,6 +1,6 @@
 -module(rebar3_shine).
 
--export([init/1, do/1, format_error/1, extract_tests/1]).
+-export([init/1, do/1, format_error/1, extract_test_modules/1, extract_tests/1]).
 
 -define(PROVIDER, shine).
 -define(DEPS, [app_discovery]).
@@ -28,15 +28,25 @@ do(State) ->
                             fun(State1) ->
                                {ok, State2} = rebar_prv_compile:do(State1),
 
-                               shine:run_suite([{test_module,
-                                                 "test_project_test",
-                                                 extract_tests(test_project_test)}]),
+                               Paths = filelib:wildcard("gen/test/**/*.erl"),
+                               Suite = extract_test_modules(Paths),
+
+                               shine:run_suite(Suite),
+
                                {ok, State2}
                             end).
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
+
+extract_test_modules(Paths) ->
+    lists:map(fun(Path) ->
+                 ModuleName = filename:basename(Path, ".erl"),
+                 Module = list_to_atom(ModuleName),
+                 {test_module, ModuleName, extract_tests(Module)}
+              end,
+              Paths).
 
 extract_tests(Module) ->
     lists:filtermap(fun({Function, Arity}) ->

--- a/test/rebar3_shine_test.erl
+++ b/test/rebar3_shine_test.erl
@@ -1,6 +1,11 @@
 -module(rebar3_shine_test).
 -include_lib("eunit/include/eunit.hrl").
- 
+
+extract_test_modules_test() ->
+    Paths = ["gen/test/fixtures@passing_test_module.erl"],
+    [{test_module, "fixtures@passing_test_module", [{test, Test}]}] = rebar3_shine:extract_test_modules(Paths),
+    ?assertEqual({ok, nil}, Test()).
+
 extract_tests_passing_test() ->
     Module = fixtures@passing_test_module,
     [{test, Test}] = rebar3_shine:extract_tests(Module),


### PR DESCRIPTION
This patch removed the hardcoded test module in rebar3_shine, allowing
Shine to find generated test files automatically.

Closes #15.