### PR TITLE
Check in /gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ _build
 docs
 ebin
 erl_crash.dump
-gen
 log
 logs
 rebar3.crashdump

--- a/gen/src/shine.erl
+++ b/gen/src/shine.erl
@@ -1,0 +1,32 @@
+-module(shine).
+-compile(no_auto_import).
+
+-export([init/1, start/1, run/2]).
+
+init(State) ->
+    {ok, State@1} = rebar3_shine:init(State),
+    {ok, State@1}.
+
+start(Suite) ->
+    {ok, Stats} = shine@stats:start(),
+    run(Suite, Stats),
+    Stats@1 = shine@stats:stats(Stats),
+    shine@formatter:print_stats(Stats@1),
+    erlang:element(3, Stats@1).
+
+run(Suite, Stats) ->
+    gleam@list:map(
+        Suite,
+        fun(Test_module) ->
+            erlang:setelement(
+                3,
+                Test_module,
+                gleam@list:map(
+                    erlang:element(3, Test_module),
+                    fun(Test) -> Test@1 = shine@test:run(Test),
+                        shine@stats:test_finished(Stats, Test@1),
+                        shine@formatter:print_test(Test@1) end
+                )
+            )
+        end
+    ).

--- a/gen/src/shine@formatter.erl
+++ b/gen/src/shine@formatter.erl
@@ -1,0 +1,78 @@
+-module(shine@formatter).
+-compile(no_auto_import).
+
+-export([print_test/1, format_test/1, print_stats/1, format_stats/1]).
+
+print_test(Test) ->
+    gleam@io:print(format_test(Test)),
+    Test.
+
+format_test(Test) ->
+    case erlang:element(4, Test) of
+        {passed, _} ->
+            <<"."/utf8>>;
+
+        {failed, {error, Error}} ->
+            Test_name = test_name(Test),
+            Result = inspect(Error),
+            gleam@string:append(
+                gleam@string:append(
+                    gleam@string:append(
+                        gleam@string:append(<<"F\n"/utf8>>, Test_name),
+                        <<":\n"/utf8>>
+                    ),
+                    Result
+                ),
+                <<"\n"/utf8>>
+            )
+    end.
+
+print_stats(Stats) ->
+    gleam@io:print(format_stats(Stats)),
+    Stats.
+
+format_stats(Stats) ->
+    gleam@string:append(
+        gleam@string:append(
+            gleam@string:append(
+                gleam@string:append(
+                    <<"\n"/utf8>>,
+                    pluralize(erlang:element(2, Stats), <<"test"/utf8>>)
+                ),
+                <<", "/utf8>>
+            ),
+            pluralize(erlang:element(3, Stats), <<"failure"/utf8>>)
+        ),
+        <<".\n"/utf8>>
+    ).
+
+test_name(Test) ->
+    gleam@string:append(
+        gleam@string:append(
+            gleam@string:append(erlang:element(2, Test), <<":"/utf8>>),
+            erlang:element(3, Test)
+        ),
+        <<"/0"/utf8>>
+    ).
+
+inspect(Term) ->
+    [Char_list, _] = io_lib:format(<<"~tp\n"/utf8>>, [Term]),
+    erlang:list_to_binary(Char_list).
+
+pluralize(Count, Singular) ->
+    case Count of
+        1 ->
+            gleam@string:append(<<"1 "/utf8>>, Singular);
+
+        _ ->
+            gleam@string:append(
+                gleam@string:append(
+                    gleam@string:append(
+                        gleam@int:to_string(Count),
+                        <<" "/utf8>>
+                    ),
+                    Singular
+                ),
+                <<"s"/utf8>>
+            )
+    end.

--- a/gen/src/shine@stats.erl
+++ b/gen/src/shine@stats.erl
@@ -1,0 +1,38 @@
+-module(shine@stats).
+-compile(no_auto_import).
+
+-export([start/0, stats/1, test_finished/2]).
+
+start() ->
+    gleam@otp@actor:start({test_stats, 0, 0}, fun handle_message/2).
+
+stats(Reporter) ->
+    gleam@otp@actor:call(Reporter, fun(A) -> {get_stats, A} end, 100).
+
+test_finished(Reporter, Test) ->
+    gleam@otp@actor:send(Reporter, {test_finished, Test}).
+
+handle_message(Message, Stats) ->
+    case Message of
+        {get_stats, Channel} ->
+            gleam@otp@actor:send(Channel, Stats),
+            {continue, Stats};
+
+        {test_finished, Test} ->
+            case erlang:element(4, Test) of
+                {passed, _} ->
+                    {continue,
+                     {test_stats,
+                      erlang:element(2, Stats)
+                      + 1,
+                      erlang:element(3, Stats)}};
+
+                {failed, _} ->
+                    {continue,
+                     {test_stats,
+                      erlang:element(2, Stats)
+                      + 1,
+                      erlang:element(3, Stats)
+                      + 1}}
+            end
+    end.

--- a/gen/src/shine@stats_GetStats.hrl
+++ b/gen/src/shine@stats_GetStats.hrl
@@ -1,0 +1,1 @@
+-record(get_stats, {reply_channel}).

--- a/gen/src/shine@stats_TestFinished.hrl
+++ b/gen/src/shine@stats_TestFinished.hrl
@@ -1,0 +1,1 @@
+-record(test_finished, {test}).

--- a/gen/src/shine@stats_TestStats.hrl
+++ b/gen/src/shine@stats_TestStats.hrl
@@ -1,0 +1,1 @@
+-record(test_stats, {tests, failures}).

--- a/gen/src/shine@test.erl
+++ b/gen/src/shine@test.erl
@@ -1,0 +1,20 @@
+-module(shine@test).
+-compile(no_auto_import).
+
+-export([new/3, run/1]).
+
+new(Module, Name, Fun) ->
+    {test, Module, Name, upcoming, wrap(Fun)}.
+
+run(Test) ->
+    State = case (erlang:element(5, Test))() of
+        {error, E} ->
+            {failed, {error, E}};
+
+        {ok, A} ->
+            {passed, {ok, A}}
+    end,
+    erlang:setelement(4, Test, State).
+
+wrap(Fun) ->
+    fun() -> shine_external:rescue(Fun) end.

--- a/gen/src/shine@test_Test.hrl
+++ b/gen/src/shine@test_Test.hrl
@@ -1,0 +1,1 @@
+-record(test, {module, name, state, run}).

--- a/gen/src/shine_TestModule.hrl
+++ b/gen/src/shine_TestModule.hrl
@@ -1,0 +1,1 @@
+-record(test_module, {name, tests}).

--- a/gen/test/fixtures.erl
+++ b/gen/test/fixtures.erl
@@ -1,0 +1,30 @@
+-module(fixtures).
+-compile(no_auto_import).
+
+-export([test/0, test_failing/0, test_passed/0, test_failed/0, stats/0, stats_singular/0]).
+
+test() ->
+    shine@test:new(
+        <<"shine_test"/utf8>>,
+        <<"passing_test"/utf8>>,
+        fun() -> gleam@dynamic:from(<<""/utf8>>) end
+    ).
+
+test_failing() ->
+    shine@test:new(
+        <<"shine_test"/utf8>>,
+        <<"failing_test"/utf8>>,
+        fun() -> gleam@should:equal(1, 2) end
+    ).
+
+test_passed() ->
+    shine@test:run(test()).
+
+test_failed() ->
+    shine@test:run(test_failing()).
+
+stats() ->
+    {test_stats, 3, 2}.
+
+stats_singular() ->
+    {test_stats, 1, 1}.

--- a/gen/test/fixtures@passing_test_module.erl
+++ b/gen/test/fixtures@passing_test_module.erl
@@ -1,0 +1,7 @@
+-module(fixtures@passing_test_module).
+-compile(no_auto_import).
+
+-export([passing_test/0]).
+
+passing_test() ->
+    nil.

--- a/gen/test/shine@formatter_test.erl
+++ b/gen/test/shine@formatter_test.erl
@@ -1,0 +1,30 @@
+-module(shine@formatter_test).
+-compile(no_auto_import).
+
+-export([format_passed_test/0, format_failed_test/0, format_report_test/0, format_report_singular_test/0]).
+
+format_passed_test() ->
+    gleam@should:equal(
+        shine@formatter:format_test(fixtures:test_passed()),
+        <<"."/utf8>>
+    ).
+
+format_failed_test() ->
+    gleam@should:be_true(
+        gleam@string:starts_with(
+            shine@formatter:format_test(fixtures:test_failed()),
+            <<"F\nshine_test:failing_test/0:\n{errored,\n    {assertEqual"/utf8>>
+        )
+    ).
+
+format_report_test() ->
+    gleam@should:equal(
+        shine@formatter:format_stats(fixtures:stats()),
+        <<"\n3 tests, 2 failures.\n"/utf8>>
+    ).
+
+format_report_singular_test() ->
+    gleam@should:equal(
+        shine@formatter:format_stats(fixtures:stats_singular()),
+        <<"\n1 test, 1 failure.\n"/utf8>>
+    ).

--- a/gen/test/shine@stats_test.erl
+++ b/gen/test/shine@stats_test.erl
@@ -1,0 +1,24 @@
+-module(shine@stats_test).
+-compile(no_auto_import).
+
+-export([start_test/0, stats_test/0, test_finished_passed_test/0, test_finished_failed_test/0]).
+
+start_test() ->
+    {ok, Stats} = shine@stats:start(),
+    gleam@should:be_true(
+        gleam@otp@process:is_alive(gleam@otp@process:pid(Stats))
+    ).
+
+stats_test() ->
+    {ok, Stats} = shine@stats:start(),
+    gleam@should:equal(shine@stats:stats(Stats), {test_stats, 0, 0}).
+
+test_finished_passed_test() ->
+    {ok, Stats} = shine@stats:start(),
+    shine@stats:test_finished(Stats, fixtures:test_passed()),
+    gleam@should:equal(shine@stats:stats(Stats), {test_stats, 1, 0}).
+
+test_finished_failed_test() ->
+    {ok, Stats} = shine@stats:start(),
+    shine@stats:test_finished(Stats, fixtures:test_failed()),
+    gleam@should:equal(shine@stats:stats(Stats), {test_stats, 1, 1}).

--- a/gen/test/shine@test_test.erl
+++ b/gen/test/shine@test_test.erl
@@ -1,0 +1,33 @@
+-module(shine@test_test).
+-compile(no_auto_import).
+
+-export([run_test/0, wrap_passing_test/0, new_failing_test/0]).
+
+run_test() ->
+    Test = shine@test:run(fixtures:test()),
+    {passed, {ok, Dynamic_result}} = erlang:element(4, Test),
+    {ok, Result} = gleam@dynamic:string(Dynamic_result),
+    gleam@should:equal(Result, <<""/utf8>>).
+
+wrap_passing_test() ->
+    T = shine@test:new(
+        <<"module"/utf8>>,
+        <<"name"/utf8>>,
+        fun() -> gleam@should:equal(1, 1) end
+    ),
+    gleam@should:equal(erlang:element(2, T), <<"module"/utf8>>),
+    gleam@should:equal(erlang:element(3, T), <<"name"/utf8>>),
+    gleam@should:be_ok((erlang:element(5, T))()).
+
+new_failing_test() ->
+    T = shine@test:new(
+        <<"module"/utf8>>,
+        <<"name"/utf8>>,
+        fun() -> gleam@should:equal(1, 2) end
+    ),
+    {error, {Kind, Error, Stack}} = (erlang:element(5, T))(),
+    {ok, {Dynamic_kind, _}} = gleam@dynamic:tuple2(Error),
+    {ok, Error_kind} = gleam@dynamic:atom(Dynamic_kind),
+    gleam@should:equal(gleam@atom:to_string(Kind), <<"errored"/utf8>>),
+    gleam@should:equal(gleam@atom:to_string(Error_kind), <<"assertEqual"/utf8>>),
+    gleam@should:be_ok(gleam@dynamic:list(Stack)).

--- a/gen/test/shine_test.erl
+++ b/gen/test/shine_test.erl
@@ -1,0 +1,22 @@
+-module(shine_test).
+-compile(no_auto_import).
+
+-export([start_test/0, start_with_failing_test/0, run_test/0]).
+
+start_test() ->
+    Suite = [{test_module, <<"test"/utf8>>, [fixtures:test()]}],
+    gleam@should:equal(shine:start(Suite), 0).
+
+start_with_failing_test() ->
+    Suite = [{test_module, <<"test"/utf8>>, [fixtures:test_failing()]}],
+    gleam@should:equal(shine:start(Suite), 1).
+
+run_test() ->
+    {ok, Stats} = shine@stats:start(),
+    Suite = [{test_module, <<"test"/utf8>>, [fixtures:test()]}],
+    [Test_module] = shine:run(Suite, Stats),
+    [Test] = erlang:element(3, Test_module),
+    gleam@should:equal(
+        erlang:element(4, Test),
+        {passed, {ok, gleam@dynamic:from(<<""/utf8>>)}}
+    ).


### PR DESCRIPTION
Check in the /gen directory to fix the compilation issue when installing through git:

    ===> Compile (apps)
    ===> Skipping gleam_stdlib v0.13.0 as an app of the same name has already been fetched
    ===> Compile (apps)
    ===> error undef [{shine,module_info,[exports],[]},
                      {rebar_plugins,validate_plugin,1,
                          [{file,
                               "/home/runner/work/rebar3/rebar3/src/rebar_plugins.erl"},
                           {line,165}]},
                      {rebar_plugins,handle_plugin,4,
                          [{file,
                               "/home/runner/work/rebar3/rebar3/src/rebar_plugins.erl"},
                           {line,133}]},
                      {rebar_plugins,'-handle_plugins/4-fun-0-',4,
                          [{file,
                               "/home/runner/work/rebar3/rebar3/src/rebar_plugins.erl"},
                           {line,100}]},
                      {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
                      {rebar_plugins,handle_plugins,4,
                          [{file,
                               "/home/runner/work/rebar3/rebar3/src/rebar_plugins.erl"},
                           {line,99}]},
                      {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
                      {rebar_plugins,project_plugins_install,1,
                          [{file,
                               "/home/runner/work/rebar3/rebar3/src/rebar_plugins.erl"},
                           {line,23}]}]
    ===> Errors loading plugin {shine,
                                   {git,
                                       "https://github.com/jeffkreeftmeijer/shine.git",
                                       {branch,"main"}}}. Run rebar3 with DEBUG=1 set to see errors.
    ===> Command shine not found
